### PR TITLE
Empty date in options resulted in a error

### DIFF
--- a/www/DatePicker.js
+++ b/www/DatePicker.js
@@ -58,7 +58,7 @@ DatePicker.prototype.show = function(options, cb) {
 
     var defaults = {
         mode: 'datetime',
-        date: new Date(),
+        date: formatDate(new Date()),
         allowOldDates: true,
         allowFutureDates: true,
         minDate: '',


### PR DESCRIPTION
because of milliseconds in the Date to string conversion.
